### PR TITLE
Docs rebranding 4.3 about section only

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -13,7 +13,7 @@ Complying with licenses
 What are licenses?
 ------------------
 
-Godot is created and distributed under the `MIT License <https://opensource.org/licenses/MIT>`_.
+Redot is created and distributed under the `MIT License <https://opensource.org/licenses/MIT>`_.
 It doesn't have a sole owner, as every contributor that submits code to
 the project does it under this same license and keeps ownership of their
 contribution.
@@ -31,7 +31,7 @@ with the original one.
 
 .. tip::
 
-    Alongside the Godot license text, remember to also list third-party notices
+    Alongside the Redot license text, remember to also list third-party notices
     for assets you're using, such as textures, models, sounds, music and fonts.
     This includes free assets, which often come with licenses that require
     attribution.
@@ -44,9 +44,10 @@ text somewhere in your game or derivative project.
 
 This text reads as follows::
 
-    This game uses Godot Engine, available under the following license:
+    This game uses Redot Engine, available under the following license:
 
-    Copyright (c) 2014-present the Redot community, modified from an original work by G-dot Engine contributors.
+    Copyright (c) 2024-present the Redot community, modified from an original work by Redot Engine contributors.
+    Copyright (c) 2014-present the Godot community, modified from an original work by Godot Engine contributors.
     Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -67,13 +68,13 @@ This text reads as follows::
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
-Beside its own MIT license, Godot includes code from a number of third-party
+Beside its own MIT license, Redot includes code from a number of third-party
 libraries. See :ref:`doc_complying_with_licenses_thirdparty` for details.
 
 .. note::
 
     Your games do not need to be under the same license. You are free to release
-    your Godot projects under any license and to create commercial games with
+    your Redot projects under any license and to create commercial games with
     the engine.
 
 Inclusion
@@ -118,13 +119,13 @@ If the game includes a printed manual, the license text can be included there.
 Link to the license
 ^^^^^^^^^^^^^^^^^^^
 
-The Godot Engine developers consider that a link to ``godotengine.org/license``
+The Redot Engine developers consider that a link to ``redotengine.org/license``
 in your game documentation or credits would be an acceptable way to satisfy
 the license terms.
 
 .. tip::
 
-    Godot provides several methods to get license information in the
+    Redot provides several methods to get license information in the
     :ref:`Engine <class_Engine>` singleton. This allows you to source the
     license information directly from the engine binary, which prevents the
     information from becoming outdated if you update engine versions.
@@ -143,19 +144,19 @@ the license terms.
 Third-party licenses
 --------------------
 
-Godot itself contains software written by
-`third parties <https://github.com/godotengine/godot/blob/master/thirdparty/README.md>`_,
-which is compatible with, but not covered by Godot's MIT license.
+Redot itself contains software written by
+`third parties <https://github.com/Redot-Engine/redot-engine/blob/master/README.md>`_,
+which is compatible with, but not covered by Redot's MIT license.
 
 Many of these dependencies are distributed under permissive open source licenses
 which require attribution by explicitly citing their copyright statement and
 license text in the final product's documentation.
 
-Given the scope of the Godot project, this is fairly difficult to do thoroughly.
-For the Godot editor, the full documentation of third-party copyrights and
-licenses is provided in the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_
+Given the scope of the Redot project, this is fairly difficult to do thoroughly.
+For the Redot editor, the full documentation of third-party copyrights and
+licenses is provided in the `COPYRIGHT.txt <https://github.com/Redot-Engine/redot-engine/blob/master/COPYRIGHT.txt>`_
 file.
 
 A good option for end users to document third-party licenses is to include this
 file in your project's distribution, which you can e.g. rename to
-``GODOT_COPYRIGHT.txt`` to prevent any confusion with your own code and assets.
+``REDOT_COPYRIGHT.txt`` to prevent any confusion with your own code and assets.

--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -29,7 +29,7 @@ Development
 Migrating
 ^^^^^^^^^
 
-- :ref:`doc_upgrading_to_godot_4.2`
+- :ref:`doc_upgrading_to_redot_4.2`
 
 I/O
 ^^^
@@ -53,7 +53,7 @@ Development
 Migrating
 ^^^^^^^^^
 
-- :ref:`doc_upgrading_to_godot_4.1`
+- :ref:`doc_upgrading_to_redot_4.1`
 
 Physics
 ^^^^^^^
@@ -101,7 +101,7 @@ Development
 Migrating
 ^^^^^^^^^
 
-- :ref:`doc_upgrading_to_godot_4`
+- :ref:`doc_upgrading_to_redot_4`
 
 Physics
 ^^^^^^^
@@ -362,13 +362,13 @@ Project workflow
 Best Practices:
 
 - :ref:`doc_introduction_best_practices`
-- :ref:`doc_what_are_godot_classes`
+- :ref:`doc_what_are_redot_classes`
 - :ref:`doc_scene_organization`
 - :ref:`doc_scenes_versus_scripts`
 - :ref:`doc_autoloads_versus_internal_nodes`
 - :ref:`doc_node_alternatives`
-- :ref:`doc_godot_interfaces`
-- :ref:`doc_godot_notifications`
+- :ref:`doc_redot_interfaces`
+- :ref:`doc_redot_notifications`
 - :ref:`doc_data_preferences`
 - :ref:`doc_logic_preferences`
 
@@ -411,7 +411,7 @@ Viewports
 Shading
 ^^^^^^^
 
-- :ref:`doc_converting_glsl_to_godot_shaders`
+- :ref:`doc_converting_glsl_to_redot_shaders`
 - :ref:`doc_advanced_postprocessing`
 
 Shading Reference:

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -8,35 +8,35 @@
 Frequently asked questions
 ==========================
 
-What can I do with Godot? How much does it cost? What are the license terms?
+What can I do with Redot? How much does it cost? What are the license terms?
 ----------------------------------------------------------------------------
 
-Godot is `Free and open source Software <https://en.wikipedia.org/wiki/Free_and_open_source_software>`_
+Redot is `Free and open source Software <https://en.wikipedia.org/wiki/Free_and_open_source_software>`_
 available under the `OSI-approved <https://opensource.org/licenses/MIT>`_ MIT license. This means it is
 free as in "free speech" as well as in "free beer."
 
 In short:
 
-* You are free to download and use Godot for any purpose: personal, non-profit, commercial, or otherwise.
-* You are free to modify, distribute, redistribute, and remix Godot to your heart's content, for any reason,
+* You are free to download and use Redot for any purpose: personal, non-profit, commercial, or otherwise.
+* You are free to modify, distribute, redistribute, and remix Redot to your heart's content, for any reason,
   both non-commercially and commercially.
 
 All the contents of this accompanying documentation are published under the permissive Creative Commons
 Attribution 3.0 (`CC BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with attribution
-to "Juan Linietsky, Ariel Manzur and the Godot Engine community."
+to "Godot founders, Godot Engine Community and the Redot Engine community."
 
 Logos and icons are generally under the same Creative Commons license. Note
-that some third-party libraries included with Godot's source code may have
+that some third-party libraries included with Redot's source code may have
 different licenses.
 
-For full details, look at the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_
-as well as the `LICENSE.txt <https://github.com/godotengine/godot/blob/master/LICENSE.txt>`_
-and `LOGO_LICENSE.txt <https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.txt>`_ files
-in the Godot repository.
+For full details, look at the `COPYRIGHT.txt <https://github.com/Redot-Engine/redot-engine/blob/master/COPYRIGHT.txt>`_
+as well as the `LICENSE.txt <https://github.com/Redot-Engine/redot-engine/blob/master/LICENSE.txt>`_
+and `LOGO_LICENSE.txt <https://github.com/Redot-Engine/redot-engine/blob/master/LOGO_LICENSE.txt>`_ files
+in the Redot repository.
 
-Also, see `the license page on the Godot website <https://godotengine.org/license>`_.
+Also, see `the license page on the Redot website <https://redotengine.org/license>`_.
 
-Which platforms are supported by Godot?
+Which platforms are supported by Redot?
 ---------------------------------------
 
 **For the editor:**
@@ -45,7 +45,7 @@ Which platforms are supported by Godot?
 * macOS
 * Linux, \*BSD
 * Android (experimental)
-* `Web <https://editor.godotengine.org/>`__ (experimental)
+* `Web <https://redotengine.org/>`__ (experimental)
 
 **For exporting your games:**
 
@@ -59,32 +59,32 @@ Which platforms are supported by Godot?
 Both 32- and 64-bit binaries are supported where it makes sense, with 64
 being the default. Official macOS builds support Apple Silicon natively as well as x86_64.
 
-Some users also report building and using Godot successfully on ARM-based
+Some users also report building and using Redot successfully on ARM-based
 systems with Linux, like the Raspberry Pi.
 
-The Godot team can't provide an open source console export due to the licensing
+The Redot team can't provide an open source console export due to the licensing
 terms imposed by console manufacturers. Regardless of the engine you use,
 though, releasing games on consoles is always a lot of work. You can read more
 about :ref:`doc_consoles`.
 
 For more on this, see the sections on :ref:`exporting <toc-learn-workflow-export>`
-and :ref:`compiling Godot yourself <toc-devel-compiling>`.
+and :ref:`compiling Redot yourself <toc-devel-compiling>`.
 
 .. note::
 
-    Godot 3 also had support for Universal Windows Platform (UWP). This platform
-    port was removed in Godot 4 due to lack of maintenance, and it being
+    Redot 3 also had support for Universal Windows Platform (UWP). This platform
+    port was removed in Redot 4 due to lack of maintenance, and it being
     deprecated by Microsoft. It is still available in the current stable release
-    of Godot 3 for interested users.
+    of Redot 3 for interested users.
 
-Which programming languages are supported in Godot?
+Which programming languages are supported in Redot?
 ---------------------------------------------------
 
-The officially supported languages for Godot are GDScript, C#, and C++.
+The officially supported languages for Redot are GDScript, C#, and C++.
 See the subcategories for each language in the :ref:`scripting <toc-learn-scripting>` section.
 
-If you are just starting out with either Godot or game development in general,
-GDScript is the recommended language to learn and use since it is native to Godot.
+If you are just starting out with either Redot or game development in general,
+GDScript is the recommended language to learn and use since it is native to Redot.
 While scripting languages tend to be less performant than lower-level languages in
 the long run, for prototyping, developing Minimum Viable Products (MVPs), and
 focusing on Time-To-Market (TTM), GDScript will provide a fast, friendly, and capable
@@ -96,11 +96,11 @@ platform. Our friendly and hard-working development community is always
 ready to tackle new problems as they arise, but since this is an open source
 project, we recommend that you first do some due diligence yourself. Searching
 through discussions on
-`open issues <https://github.com/godotengine/godot/issues?q=is%3Aopen+is%3Aissue+label%3Atopic%3Adotnet>`__
+`open issues <https://github.com/Redot-Engine/redot-engine/issues?q=is%3Aopen+is%3Aissue+label%3Atopic%3Adotnet>`__
 is a great way to start your troubleshooting.
 
 As for new languages, support is possible via third parties with GDExtensions. (See the question
-about plugins below). Work is currently underway, for example, on unofficial bindings for Godot
+about plugins below). Work is currently underway, for example, on unofficial bindings for Redot
 to `Python <https://github.com/touilleMan/godot-python>`_ and `Nim <https://github.com/pragmagic/godot-nim>`_.
 
 .. _doc_faq_what_is_gdscript:
@@ -108,9 +108,9 @@ to `Python <https://github.com/touilleMan/godot-python>`_ and `Nim <https://gith
 What is GDScript and why should I use it?
 -----------------------------------------
 
-GDScript is Godot's integrated scripting language. It was built from the ground
-up to maximize Godot's potential in the least amount of code, affording both novice
-and expert developers alike to capitalize on Godot's strengths as fast as possible.
+GDScript is Redot's integrated scripting language. It was built from the ground
+up to maximize Redot's potential in the least amount of code, affording both novice
+and expert developers alike to capitalize on Redot's strengths as fast as possible.
 If you've ever written anything in a language like Python before, then you'll feel
 right at home. For examples and a complete overview of the power GDScript offers
 you, check out the :ref:`GDScript scripting guide <doc_gdscript>`.
@@ -119,19 +119,19 @@ There are several reasons to use GDScript, but the most salient reason is the ov
 **reduction of complexity**.
 
 The original intent of creating a tightly integrated, custom scripting language for
-Godot was two-fold: first, it reduces the amount of time necessary to get up and running
-with Godot, giving developers a rapid way of exposing themselves to the engine with a
+Redot was two-fold: first, it reduces the amount of time necessary to get up and running
+with Redot, giving developers a rapid way of exposing themselves to the engine with a
 focus on productivity; second, it reduces the overall burden of maintenance, attenuates
 the dimensionality of issues, and allows the developers of the engine to focus on squashing
 bugs and improving features related to the engine core, rather than spending a lot of time
 trying to get a small set of incremental features working across a large set of languages.
 
-Since Godot is an open source project, it was imperative from the start to prioritize a
+Since Redot is an open source project, it was imperative from the start to prioritize a
 more integrated and seamless experience over attracting additional users by supporting
 more familiar programming languages, especially when supporting those more familiar
 languages would result in a worse experience. We understand if you would rather use
-another language in Godot (see the list of supported options above). That being said, if
-you haven't given GDScript a try, try it for **three days**. Just like Godot,
+another language in Redot (see the list of supported options above). That being said, if
+you haven't given GDScript a try, try it for **three days**. Just like Redot,
 once you see how powerful it is and how rapid your development becomes, we think GDScript
 will grow on you.
 
@@ -147,12 +147,12 @@ system (by using fallbacks) was complex and slow and took an enormous
 amount of code. After some experiments with `Python <https://www.python.org>`__,
 that also proved difficult to embed.
 
-The main reasons for creating a custom scripting language for Godot were:
+The main reasons for creating a custom scripting language for Redot were:
 
-1. Poor threading support in most script VMs, and Godot uses threads
+1. Poor threading support in most script VMs, and Redot uses threads
    (Lua, Python, Squirrel, JavaScript, ActionScript, etc.).
 2. Poor class-extending support in most script VMs, and adapting to
-   the way Godot works is highly inefficient (Lua, Python, JavaScript).
+   the way Redot works is highly inefficient (Lua, Python, JavaScript).
 3. Many existing languages have horrible interfaces for binding to C++, resulting in a
    large amount of code, bugs, bottlenecks, and general inefficiency (Lua, Python,
    Squirrel, JavaScript, etc.). We wanted to focus on a great engine, not a great number
@@ -167,55 +167,55 @@ The main reasons for creating a custom scripting language for Godot were:
 
 GDScript was designed to curtail the issues above, and more.
 
-What 3D model formats does Godot support?
+What 3D model formats does Redot support?
 -----------------------------------------
 
 You can find detailed information on supported formats, how to export them from
-your 3D modeling software, and how to import them for Godot in the
+your 3D modeling software, and how to import them for Redot in the
 :ref:`doc_importing_3d_scenes` documentation.
 
-Will [insert closed SDK such as FMOD, GameWorks, etc.] be supported in Godot?
+Will [insert closed SDK such as FMOD, GameWorks, etc.] be supported in Redot?
 -----------------------------------------------------------------------------
 
-The aim of Godot is to create a free and open source MIT-licensed engine that
+The aim of Redot is to create a free and open source MIT-licensed engine that
 is modular and extendable. There are no plans for the core engine development
 community to support any third-party, closed-source/proprietary SDKs, as integrating
-with these would go against Godot's ethos.
+with these would go against Redot's ethos.
 
-That said, because Godot is open source and modular, nothing prevents you or
+That said, because Redot is open source and modular, nothing prevents you or
 anyone else interested in adding those libraries as a module and shipping your
 game with them, as either open- or closed-source.
 
 To see how support for your SDK of choice could still be provided, look at the
 Plugins question below.
 
-If you know of a third-party SDK that is not supported by Godot but that offers
+If you know of a third-party SDK that is not supported by Redot but that offers
 free and open source integration, consider starting the integration work yourself.
-Godot is not owned by one person; it belongs to the community, and it grows along
+Redot is not owned by one person; it belongs to the community, and it grows along
 with ambitious community contributors like you.
 
-How can I extend Godot?
+How can I extend Redot?
 -----------------------
 
-For extending Godot, like creating Godot Editor plugins or adding support
+For extending Redot, like creating Redot Editor plugins or adding support
 for additional languages, take a look at :ref:`EditorPlugins <doc_making_plugins>`
 and tool scripts.
 
-Also, see the official blog post on GDExtension, a way to develop native extensions for Godot:
+Also, see the official blog post on GDExtension in Godot Website, a way to develop native extensions for Redot:
 
 * `Introducing GDNative's successor, GDExtension <https://godotengine.org/article/introducing-gd-extensions>`_
 
-You can also take a look at the GDScript implementation, the Godot modules,
+You can also take a look at the GDScript implementation, the Redot modules,
 as well as the `Jolt physics engine integration <https://github.com/godot-jolt/godot-jolt>`__
-for Godot. This would be a good starting point to see how another
-third-party library integrates with Godot.
+for Redot. This would be a good starting point to see how another
+third-party library integrates with Redot.
 
-How do I install the Godot editor on my system (for desktop integration)?
+How do I install the Redot editor on my system (for desktop integration)?
 -------------------------------------------------------------------------
 
-Since you don't need to actually install Godot on your system to run it,
+Since you don't need to actually install Redot on your system to run it,
 this means desktop integration is not performed automatically.
-There are two ways to overcome this. You can install Godot from
+There are two ways to overcome this. You can install Redot from
 `Steam <https://store.steampowered.com/app/404790/Godot_Engine/>`__ (all platforms),
 `Scoop <https://scoop.sh/>`__ (Windows), `Homebrew <https://brew.sh/>`__ (macOS)
 or `Flathub <https://flathub.org/apps/details/org.godotengine.Godot>`__ (Linux).
@@ -226,83 +226,83 @@ Alternatively, you can manually perform the steps that an installer would do for
 Windows
 ^^^^^^^
 
-- Move the Godot executable to a stable location (i.e. outside of your Downloads folder),
+- Move the Redot executable to a stable location (i.e. outside of your Downloads folder),
   so you don't accidentally move it and break the shortcut in the future.
-- Right-click the Godot executable and choose **Create Shortcut**.
+- Right-click the Redot executable and choose **Create Shortcut**.
 - Move the created shortcut to ``%APPDATA%\Microsoft\Windows\Start Menu\Programs``.
   This is the user-wide location for shortcuts that will appear in the Start menu.
-  You can also pin Godot in the task bar by right-clicking the executable and choosing
+  You can also pin Redot in the task bar by right-clicking the executable and choosing
   **Pin to Task Bar**.
 
 macOS
 ^^^^^
 
-Drag the extracted Godot application to ``/Applications/Godot.app``, then drag it
-to the Dock if desired. Spotlight will be able to find Godot as long as it's in
+Drag the extracted Redot application to ``/Applications/Redot.app``, then drag it
+to the Dock if desired. Spotlight will be able to find Redot as long as it's in
 ``/Applications`` or ``~/Applications``.
 
 Linux
 ^^^^^
 
-- Move the Godot binary to a stable location (i.e. outside of your Downloads folder),
+- Move the Redot binary to a stable location (i.e. outside of your Downloads folder),
   so you don't accidentally move it and break the shortcut in the future.
-- Rename and move the Godot binary to a location present in your ``PATH`` environment variable.
-  This is typically ``/usr/local/bin/godot`` or ``/usr/bin/godot``.
+- Rename and move the Redot binary to a location present in your ``PATH`` environment variable.
+  This is typically ``/usr/local/bin/redot`` or ``/usr/bin/redot``.
   Doing this requires administrator privileges,
   but this also allows you to
-  :ref:`run the Godot editor from a terminal <doc_command_line_tutorial>` by entering ``godot``.
+  :ref:`run the Redot editor from a terminal <doc_command_line_tutorial>` by entering ``redot``.
 
-  - If you cannot move the Godot editor binary to a protected location, you can
+  - If you cannot move the Redot editor binary to a protected location, you can
     keep the binary somewhere in your home directory, and modify the ``Path=``
     line in the ``.desktop`` file linked below to contain the full *absolute* path
-    to the Godot binary.
+    to the Redot binary.
 
-- Save `this .desktop file <https://raw.githubusercontent.com/godotengine/godot/master/misc/dist/linux/org.godotengine.Godot.desktop>`__
+- Save `this .desktop file <https://raw.githubusercontent.com/redot-engine/redot-engine/master/misc/dist/linux/org.godotengine.Godot.desktop>`__
   to ``$HOME/.local/share/applications/``. If you have administrator privileges,
   you can also save the ``.desktop`` file to ``/usr/local/share/applications``
   to make the shortcut available for all users.
 
-Is the Godot editor a portable application?
+Is the Redot editor a portable application?
 -------------------------------------------
 
-In its default configuration, Godot is *semi-portable*. Its executable can run
+In its default configuration, Redot is *semi-portable*. Its executable can run
 from any location (including non-writable locations) and never requires
 administrator privileges.
 
 However, configuration files will be written to the user-wide configuration or
 data directory. This is usually a good approach, but this means configuration files
-will not carry across machines if you copy the folder containing the Godot executable.
+will not carry across machines if you copy the folder containing the Redot executable.
 See :ref:`doc_data_paths` for more information.
 
 If *true* portable operation is desired (e.g. for use on a USB stick),
 follow the steps in :ref:`doc_data_paths_self_contained_mode`.
 
-Why does Godot prioritize Vulkan and OpenGL over Direct3D?
+Why does Redot prioritize Vulkan and OpenGL over Direct3D?
 ----------------------------------------------------------
 
-Godot aims for cross-platform compatibility and open standards first and
+Redot aims for cross-platform compatibility and open standards first and
 foremost. OpenGL and Vulkan are the technologies that are both open and
 available on (nearly) all platforms. Thanks to this design decision, a project
-developed with Godot on Windows will run out of the box on Linux, macOS, and
+developed with Redot on Windows will run out of the box on Linux, macOS, and
 more.
 
 While Vulkan and OpenGL remain our primary focus for their open standard and
-cross-platform benefits, Godot 4.3 introduced experimental support for Direct3D 12.
+cross-platform benefits, Redot 4.3 introduced experimental support for Direct3D 12.
 This addition aims to enhance performance and compatibility on platforms where
 Direct3D 12 is prevalent, such as Windows and Xbox. However, Vulkan and OpenGL
 will continue as the default rendering backends on all platforms, including Windows.
 
-Why does Godot aim to keep its core feature set small?
+Why does Redot aim to keep its core feature set small?
 ------------------------------------------------------
 
-Godot intentionally does not include features that can be implemented by add-ons
+Redot intentionally does not include features that can be implemented by add-ons
 unless they are used very often. One example of something not used often is
 advanced artificial intelligence functionality.
 
 There are several reasons for this:
 
 - **Code maintenance and surface for bugs.** Every time we accept new code in
-  the Godot repository, existing contributors often take the responsibility of
+  the Redot repository, existing contributors often take the responsibility of
   maintaining it. Some contributors don't always stick around after getting
   their code merged, which can make it difficult for us to maintain the code in
   question. This can lead to poorly maintained features with bugs that are never
@@ -311,24 +311,24 @@ There are several reasons for this:
 
 - **Ease of contribution.** By keeping the codebase small and tidy, it can remain
   fast and easy to compile from source. This makes it easier for new
-  contributors to get started with Godot, without requiring them to purchase
+  contributors to get started with Redot, without requiring them to purchase
   high-end hardware.
 
 - **Keeping the binary size small for the editor.** Not everyone has a fast Internet
-  connection. Ensuring that everyone can download the Godot editor, extract it
-  and run it in less than 5 minutes makes Godot more accessible to developers in
+  connection. Ensuring that everyone can download the Redot editor, extract it
+  and run it in less than 5 minutes makes Redot more accessible to developers in
   all countries.
 
 - **Keeping the binary size small for export templates.** This directly impacts the
-  size of projects exported with Godot. On mobile and web platforms, keeping
+  size of projects exported with Redot. On mobile and web platforms, keeping
   file sizes low is important to ensure fast installation and loading on
   underpowered devices. Again, there are many countries where high-speed
   Internet is not readily available. To add to this, strict data usage caps are
   often in effect in those countries.
 
 For all the reasons above, we have to be selective of what we can accept as core
-functionality in Godot. This is why we are aiming to move some core
-functionality to officially supported add-ons in future versions of Godot.
+functionality in Redot. This is why we are aiming to move some core
+functionality to officially supported add-ons in future versions of Redot.
 In terms of binary size, this also has the advantage of making you pay only for
 what you actually use in your project. (In the meantime, you can
 :ref:`compile custom export templates with unused features disabled <doc_optimizing_for_size>`
@@ -358,7 +358,7 @@ horizontal FOV.
    resolution, the larger your assets, the more memory they will take
    and the longer the time it will take for loading.
 
-2. Use the stretch options in Godot; canvas items stretching while keeping
+2. Use the stretch options in Redot; canvas items stretching while keeping
    aspect ratios works best. Check the :ref:`doc_multiple_resolutions` tutorial
    on how to achieve this.
 
@@ -373,20 +373,20 @@ horizontal FOV.
 
 And that's it! Your game should work in multiple resolutions.
 
-When is the next release of Godot out?
+When is the next release of Redot out?
 --------------------------------------
 
 When it's ready! See :ref:`doc_release_policy_when_is_next_release_out` for more
 information.
 
-Which Godot version should I use for a new project?
+Which Redot version should I use for a new project?
 ---------------------------------------------------
 
-We recommend using Godot 4.x for new projects, but depending on the feature set
+We recommend using Redot 4.x for new projects, but depending on the feature set
 you need, it may be better to use 3.x instead. See
 :ref:`doc_release_policy_which_version_should_i_use` for more information.
 
-Should I upgrade my project to use new Godot versions?
+Should I upgrade my project to use new Redot versions?
 ------------------------------------------------------
 
 Some new versions are safer to upgrade to than others. In general, whether you
@@ -396,24 +396,24 @@ should upgrade depends on your project's circumstances. See
 I would like to contribute! How can I get started?
 --------------------------------------------------
 
-Awesome! As an open source project, Godot thrives off of the innovation and
+Awesome! As an open source project, Redot thrives off of the innovation and
 the ambition of developers like you.
 
-The best way to start contributing to Godot is by using it and reporting
-any `issues <https://github.com/godotengine/godot/issues>`_ that you might experience.
+The best way to start contributing to Redot is by using it and reporting
+any `issues <https://github.com/Redot-Engine/redot-engine/issues>`_ that you might experience.
 A good bug report with clear reproduction steps helps your fellow contributors
 fix bugs quickly and efficiently. You can also report issues you find in the
-`online documentation <https://github.com/godotengine/godot-docs/issues>`_.
+`online documentation <https://github.com/Redot-Engine/redot-docs/issues>`_.
 
 If you feel ready to submit your first PR, pick any issue that resonates with you from
 one of the links above and try your hand at fixing it. You will need to learn how to
 compile the engine from sources, or how to build the documentation. You also need to
-get familiar with Git, a version control system that Godot developers use.
+get familiar with Git, a version control system that Redot developers use.
 
 We explain how to work with the engine source, how to edit the documentation, and
 what other ways to contribute are there in our :ref:`documentation for contributors <doc_ways_to_contribute>`.
 
-I have a great idea for Godot. How can I share it?
+I have a great idea for Redot. How can I share it?
 --------------------------------------------------
 
 We are always looking for suggestions about how to improve the engine. User feedback
@@ -422,31 +422,31 @@ you might face while working on your project are a great data point for us when 
 engine enhancements.
 
 If you experience a usability problem or are missing a feature in the current version of
-Godot, start by discussing it with our `community <https://godotengine.org/community/>`_.
+Redot, start by discussing it with our `community <https://redotengine.org/community/>`_.
 There may be other, perhaps better, ways to achieve the desired result that community members
 could suggest. And you can learn if other users experience the same issue, and figure out
 a good solution together.
 
 If you come up with a well-defined idea for the engine, feel free to open a
-`proposal issue <https://github.com/godotengine/godot-proposals/issues>`_.
+`proposal issue <https://github.com/Redot-Engine/redot-proposals/issues>`_.
 Try to be specific and concrete while describing your problem and your proposed
 solution — only actionable proposals can be considered. It is not required, but
 if you want to implement it yourself, that's always appreciated!
 
 If you only have a general idea without specific details, you can open a
-`proposal discussion <https://github.com/godotengine/godot-proposals/discussions>`_.
+`proposal discussion <https://github.com/Redot-Engine/redot-proposals/discussions>`_.
 These can be anything you want, and allow for a free-form discussion in search of
 a solution. Once you find one, a proposal issue can be opened.
 
-Please, read the `readme <https://github.com/godotengine/godot-proposals/blob/master/README.md>`_
+Please, read the `readme <https://github.com/Redot-Engine/redot-proposals/blob/master/README.md>`_
 document before creating a proposal to learn more about the process.
 
 .. _doc_faq_non_game_applications:
 
-Is it possible to use Godot to create non-game applications?
+Is it possible to use Redot to create non-game applications?
 ------------------------------------------------------------
 
-Yes! Godot features an extensive built-in UI system, and its small distribution
+Yes! Redot features an extensive built-in UI system, and its small distribution
 size can make it a suitable alternative to frameworks like Electron or Qt.
 
 When creating a non-game application, make sure to enable
@@ -455,53 +455,53 @@ in the Project Settings to decrease CPU and GPU usage.
 
 Check out `Material Maker <https://github.com/RodZill4/material-maker>`__ and
 `Pixelorama <https://github.com/Orama-Interactive/Pixelorama>`__ for examples of
-open source applications made with Godot.
+open source applications made with Redot.
 
-.. _doc_faq_use_godot_as_library:
+.. _doc_faq_use_redot_as_library:
 
-Is it possible to use Godot as a library?
+Is it possible to use Redot as a library?
 -----------------------------------------
 
-Godot is meant to be used with its editor. We recommend you give it a try, as it
+Redot is meant to be used with its editor. We recommend you give it a try, as it
 will most likely save you time in the long term. There are no plans to make
-Godot usable as a library, as it would make the rest of the engine more
+Redot usable as a library, as it would make the rest of the engine more
 convoluted and difficult to use for casual users.
 
 If you want to use a rendering library, look into using an established rendering
 engine instead. Keep in mind rendering engines usually have smaller communities
-compared to Godot. This will make it more difficult to find answers to your
+compared to Redot. This will make it more difficult to find answers to your
 questions.
 
-What user interface toolkit does Godot use?
+What user interface toolkit does Redot use?
 -------------------------------------------
 
-Godot does not use a standard :abbr:`GUI (Graphical User Interface)` toolkit
-like GTK, Qt or wxWidgets. Instead, Godot uses its own user interface toolkit,
+Redot does not use a standard :abbr:`GUI (Graphical User Interface)` toolkit
+like GTK, Qt or wxWidgets. Instead, Redot uses its own user interface toolkit,
 rendered using OpenGL ES or Vulkan. This toolkit is exposed in the form of
 Control nodes, which are used to render the editor (which is written in C++).
 These Control nodes can also be used in projects from any scripting language
-supported by Godot.
+supported by Redot.
 
 This custom toolkit makes it possible to benefit from hardware acceleration and
 have a consistent appearance across all platforms. On top of that, it doesn't
 have to deal with the LGPL licensing caveats that come with GTK or Qt. Lastly,
-this means Godot is "eating its own dog food" since the editor itself is one of
-the most complex users of Godot's UI system.
+this means Redot is "eating its own dog food" since the editor itself is one of
+the most complex users of Redot's UI system.
 
-This custom UI toolkit :ref:`can't be used as a library <doc_faq_use_godot_as_library>`,
+This custom UI toolkit :ref:`can't be used as a library <doc_faq_use_redot_as_library>`,
 but you can still
-:ref:`use Godot to create non-game applications by using the editor <doc_faq_non_game_applications>`.
+:ref:`use Redot to create non-game applications by using the editor <doc_faq_non_game_applications>`.
 
 .. _doc_faq_why_scons:
 
-Why does Godot use the SCons build system?
+Why does Redot use the SCons build system?
 ------------------------------------------
 
-Godot uses the `SCons <https://www.scons.org/>`__ build system. There are no
+Redot uses the `SCons <https://www.scons.org/>`__ build system. There are no
 plans to switch to a different build system in the near future. There are many
 reasons why we have chosen SCons over other alternatives. For example:
 
--  Godot can be compiled for a dozen different platforms: all PC
+-  Redot can be compiled for a dozen different platforms: all PC
    platforms, all mobile platforms, many consoles, and WebAssembly.
 -  Developers often need to compile for several of the platforms **at
    the same time**, or even different targets of the same platform. They
@@ -509,26 +509,26 @@ reasons why we have chosen SCons over other alternatives. For example:
    SCons can do this with no sweat, without breaking the builds.
 -  SCons will *never* break a build no matter how many changes,
    configurations, additions, removals etc.
--  Godot's build process is not simple. Several files are generated by
+-  Redot's build process is not simple. Several files are generated by
    code (binders), others are parsed (shaders), and others need to offer
    customization (:ref:`modules <doc_custom_modules_in_cpp>`). This requires
    complex logic which is easier to write in an actual programming language (like Python)
    rather than using a mostly macro-based language only meant for building.
--  Godot's build process makes heavy use of cross-compiling tools. Each
+-  Redot's build process makes heavy use of cross-compiling tools. Each
    platform has a specific detection process, and all these must be
    handled as specific cases with special code written for each.
 
 Please try to keep an open mind and get at least a little familiar with SCons if
-you are planning to build Godot yourself.
+you are planning to build Redot yourself.
 
 .. _doc_faq_why_not_stl:
 
-Why does Godot not use STL (Standard Template Library)?
+Why does Redot not use STL (Standard Template Library)?
 -------------------------------------------------------
 
-Like many other libraries (Qt as an example), Godot does not make use of STL
+Like many other libraries (Qt as an example), Redot does not make use of STL
 (with a few exceptions such as threading primitives). We believe STL is a great
-general-purpose library, but we had special requirements for Godot.
+general-purpose library, but we had special requirements for Redot.
 
 * STL templates create very large symbols, which results in huge debug binaries. We use few
   templates with very short names instead.
@@ -542,21 +542,21 @@ general-purpose library, but we had special requirements for Godot.
 * We use our custom String type, as the one provided by STL is too basic and lacks proper
   internationalization support.
 
-Why does Godot not use exceptions?
+Why does Redot not use exceptions?
 ----------------------------------
 
 We believe games should not crash, no matter what. If an unexpected
-situation happens, Godot will print an error (which can be traced even to
+situation happens, Redot will print an error (which can be traced even to
 script), but then it will try to recover as gracefully as possible and keep
 going.
 
 Additionally, exceptions significantly increase the binary size for the
 executable and result in increased compile times.
 
-Does Godot use an ECS (Entity Component System)?
+Does Redot use an ECS (Entity Component System)?
 ------------------------------------------------
 
-Godot does **not** use an ECS and relies on inheritance instead. While there
+Redot does **not** use an ECS and relies on inheritance instead. While there
 is no universally better approach, we found that using an inheritance-based approach
 resulted in better usability while still being fast enough for most use cases.
 
@@ -564,13 +564,13 @@ That said, nothing prevents you from making use of composition in your project
 by creating child Nodes with individual scripts. These nodes can then be added and
 removed at run-time to dynamically add and remove behaviors.
 
-More information about Godot's design choices can be found in
-`this article <https://godotengine.org/article/why-isnt-godot-ecs-based-game-engine>`__.
+More information about Redot's design choices can be found in
+`this article <https://godotengine.org/article/why-isnt-redot-ecs-based-game-engine>`__.
 
-Why does Godot not force users to implement DOD (Data-Oriented Design)?
+Why does Redot not force users to implement DOD (Data-Oriented Design)?
 -----------------------------------------------------------------------
 
-While Godot internally attempts to use cache coherency as much as possible,
+While Redot internally attempts to use cache coherency as much as possible,
 we believe users don't need to be forced to use DOD practices.
 
 DOD is mostly a cache coherency optimization that can only provide
@@ -580,19 +580,19 @@ modification. That is, if you are moving a few hundred sprites or enemies
 per frame, DOD won't result in a meaningful improvement in performance. In
 such a case, you should consider a different approach to optimization.
 
-The vast majority of games do not need this and Godot provides handy helpers
+The vast majority of games do not need this and Redot provides handy helpers
 to do the job for most cases when you do.
 
 If a game needs to process such a large amount of objects, our recommendation
 is to use C++ and GDExtensions for performance-heavy tasks and GDScript (or C#)
 for the rest of the game.
 
-How can I support Godot development or contribute?
+How can I support Redot development or contribute?
 --------------------------------------------------
 
 See :ref:`doc_ways_to_contribute`.
 
-Who is working on Godot? How can I contact you?
+Who is working on Redot? How can I contact you?
 -----------------------------------------------
 
-See the corresponding page on the `Godot website <https://godotengine.org/contact>`_.
+See the corresponding page on the `Redot website <https://redotengine.org/contact>`_.

--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -10,7 +10,7 @@ Introduction
     func _ready():
         print("Hello world!")
 
-Welcome to the official documentation of **Godot Engine**, the free and open source
+Welcome to the official documentation of **Redot Engine**, the free and open source
 community-driven 2D and 3D game engine! Behind this mouthful, you will find a
 powerful yet user-friendly tool that you can use to develop any kind of game,
 for any platform and with no usage restriction whatsoever.
@@ -28,26 +28,26 @@ consider checking them out. Otherwise, :ref:`Getting Started <doc_getting_starte
 is a great starting point.
 
 In case you have trouble with one of the tutorials or your project,
-you can find help on the Godot `Discord <https://discord.gg/bdcfAYM4W9>`_ community.
+you can find help on the Redot `Discord <https://discord.gg/redot>`_ community.
 
-About Godot Engine
+About Redot Engine
 ------------------
 
 A game engine is a complex tool and difficult to present in a few words.
 Here's a quick synopsis, which you are free to reuse
-if you need a quick write-up about Godot Engine:
+if you need a quick write-up about Redot Engine:
 
-    Godot Engine is a feature-packed, cross-platform game engine to create 2D
+    Redot Engine is a feature-packed, cross-platform game engine to create 2D
     and 3D games from a unified interface. It provides a comprehensive set of
     common tools, so that users can focus on making games without having to
     reinvent the wheel. Games can be exported with one click to a number of
     platforms, including the major desktop platforms (Linux, macOS, Windows),
     mobile platforms (Android, iOS), as well as Web-based platforms and consoles.
 
-    Godot is completely free and open source under the :ref:`permissive MIT
+    Redot is completely free and open source under the :ref:`permissive MIT
     license <doc_complying_with_licenses>`. No strings attached, no royalties,
     nothing. Users' games are theirs, down to the last line of engine code.
-    Godot's development is fully independent and community-driven, empowering
+    Redot's development is fully independent and community-driven, empowering
     users to help shape their engine to match their expectations.
 
 
@@ -66,36 +66,36 @@ This documentation is organized into several sections:
 - The **Manual** can be read or referenced as needed,
   in any order. It contains feature-specific tutorials and documentation.
 - **Contributing** gives information related to contributing to
-  Godot, whether to the core engine, documentation, demos or other parts.
+  Redot, whether to the core engine, documentation, demos or other parts.
   It describes how to report bugs, how contributor workflows are organized, etc.
   It also contains sections intended for advanced users and contributors,
   with information on compiling the engine, contributing to the editor,
   or developing C++ modules.
-- **Community** is dedicated to the life of Godot's community and contains a list of
+- **Community** is dedicated to the life of Redot's community and contains a list of
   recommended third-party tutorials and materials outside of this documentation.
-  It also provides details on the Asset Library. It also used to list Godot
-  communities, which are now listed on the `Godot website <https://godotengine.org/community/>`_.
-- Finally, the **Class reference** documents the full Godot API,
+  It also provides details on the Asset Library. It also used to list Redot
+  communities, which are now listed on the `Redot website <https://redotengine.org/community/>`_.
+- Finally, the **Class reference** documents the full Redot API,
   also available directly within the engine's script editor.
   You can find information on all classes, functions, signals and so on here.
 
 In addition to this documentation, you may also want to take a look at the
-various `Godot demo projects <https://github.com/godotengine/godot-demo-projects>`_.
+various `Redot demo projects <https://github.com/Redot-Engine/redot-demo-projects>`_.
 
 About this documentation
 ------------------------
 
-Members of the Godot Engine community continuously write, correct, edit, and
+Members of the Redot Engine community continuously write, correct, edit, and
 improve this documentation. We are always looking for more help. You can also
 contribute by opening Github issues or translating the documentation into your language.
 If you are interested in helping, see :ref:`Ways to contribute <doc_ways_to_contribute>`
 and :ref:`Writing documentation <doc_contributing_writing_documentation>`,
-or get in touch with the `Documentation team <https://godotengine.org/teams/#documentation>`_
-on `Godot Contributors Chat <https://chat.godotengine.org/>`_.
+or get in touch with the `Documentation team <https://redotengine.org/teams/#documentation>`_
+on `Redot Contributors Chat <https://redotengine.org/>`_.
 
 All documentation content is licensed under the permissive Creative Commons Attribution 3.0
 (`CC BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license,
-with attribution to "*Juan Linietsky, Ariel Manzur, and the Godot Engine community*"
+with attribution to "*Godot Founders, Godot Engine community and Redot Engine Community*"
 unless otherwise noted.
 
-*Have fun reading and making games with Godot Engine!*
+*Have fun reading and making games with Redot Engine!*

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -5,13 +5,13 @@
 List of features
 ================
 
-This page aims to list **all** features currently supported by Godot.
+This page aims to list **all** features currently supported by Redot.
 
 .. note::
 
     This page lists features supported by the current stable version of
-    Godot. Some of these features may not be available in the
-    `LTS release series (3.x) <https://docs.godotengine.org/en/3.5/about/list_of_features.html>`__.
+    Redot. Some of these features may not be available in the
+    `LTS release series (3.x) <https://docs.redotengine.org/en/3.5/about/list_of_features.html>`__.
 
 Platforms
 ---------
@@ -29,27 +29,27 @@ Platforms
    - Binaries are statically linked and can run on any distribution if compiled
      on an old enough base distribution.
    - Official binaries are compiled using the
-     `Godot Engine buildroot <https://github.com/godotengine/buildroot>`__,
+     `Redot Engine build scripts <https://github.com/Redot-Engine/redot-build-scripts>`__,
      allowing for binaries that work across common Linux distributions
      (including LTS variants).
 
 - Android (editor support is experimental).
 - :ref:`Web browsers <doc_using_the_web_editor>`. Experimental in 4.0,
-  using Godot 3.x is recommended instead when targeting HTML5.
+  using Redot 3.x is recommended instead when targeting HTML5.
 
 **Runs exported projects:**
 
 - iOS.
 - :ref:`Consoles <doc_consoles>`.
 
-Godot aims to be as platform-independent as possible and can be
+Redot aims to be as platform-independent as possible and can be
 :ref:`ported to new platforms <doc_custom_platform_ports>` with relative ease.
 
 .. note::
 
-    Projects written in C# using Godot 4 currently cannot be exported to the
-    web platform. To use C# on that platform, consider Godot 3 instead.
-    Android and iOS platform support is available as of Godot 4.2, but is
+    Projects written in C# using Redot 4 currently cannot be exported to the
+    web platform. To use C# on that platform, consider Redot 3 instead.
+    Android and iOS platform support is available as of Redot 4.2, but is
     experimental and :ref:`some limitations apply <doc_c_sharp_platforms>`.
 
 Editor
@@ -389,7 +389,7 @@ Rendering
 
 Most effects listed above can be adjusted for better performance or to further
 improve quality. This can be helpful when
-:ref:`using Godot for offline rendering <doc_creating_movies>`.
+:ref:`using Redot for offline rendering <doc_creating_movies>`.
 
 3D tools
 --------
@@ -470,7 +470,7 @@ Scripting
    - On the Android platform only some architectures are supported: ``arm64`` and ``x64``.
    - On the iOS platform only some architectures are supported: ``arm64``.
    - The web platform is currently unsupported. To use C# on that platform,
-     consider Godot 3 instead.
+     consider Redot 3 instead.
 
 - Using an external editor is recommended to benefit from IDE functionality.
 
@@ -481,8 +481,7 @@ Scripting
    - For scripting game logic, GDScript or C# are recommended if their
      performance is suitable.
 
-- Official GDExtension bindings for `C <https://github.com/godotengine/godot-headers>`__
-  and `C++ <https://github.com/godotengine/godot-cpp>`__.
+- Official GDExtension bindings for `C++ <https://github.com/Redot-Engine/redot-cpp>`__.
 
    - Use any build system and language features you wish.
 
@@ -632,7 +631,7 @@ Windowing and OS integration
   multiple instances of the same project).
 - Open file paths and URLs using default or custom protocol handlers (if registered on the system).
 - Parse custom command line arguments.
-- Any Godot binary (editor or exported project) can be
+- Any Redot binary (editor or exported project) can be
   :ref:`used as a headless server <doc_exporting_for_dedicated_servers>`
   by starting it with the ``--headless`` command line argument.
   This allows running the engine without a GPU or display server.
@@ -661,7 +660,7 @@ XR support (AR and VR)
 GUI system
 ----------
 
-Godot's GUI is built using the same Control nodes used to make games in Godot.
+Redot's GUI is built using the same Control nodes used to make games in Redot.
 The editor UI can easily be extended in many ways using add-ons.
 
 **Nodes:**
@@ -708,7 +707,7 @@ The editor UI can easily be extended in many ways using add-ons.
 
 - Texture-based theming using :ref:`class_StyleBoxTexture`.
 
-Godot's small distribution size can make it a suitable alternative to frameworks
+Redot's small distribution size can make it a suitable alternative to frameworks
 like Electron or Qt.
 
 Animation
@@ -735,11 +734,11 @@ File formats
 - Read and write :ref:`class_JSON` files.
 - Read and write INI-style configuration files using :ref:`class_ConfigFile`.
 
-   - Can (de)serialize any Godot datatype, including Vector2/3, Color, ...
+   - Can (de)serialize any Redot datatype, including Vector2/3, Color, ...
 
 - Read XML files using :ref:`class_XMLParser`.
 - :ref:`Load and save images, audio/video, fonts and ZIP archives <doc_runtime_loading_and_saving>`
-  in an exported project without having to go through Godot's import system.
+  in an exported project without having to go through Redot's import system.
 - Pack game data into a PCK file (custom format optimized for fast seeking),
   into a ZIP archive, or directly into the executable for single-file distribution.
 - :ref:`Export additional PCK files<doc_exporting_pcks>` that can be read
@@ -756,7 +755,7 @@ Miscellaneous
 - :ref:`Command line interface <doc_command_line_tutorial>` for automation.
 
    - Export and deploy projects using continuous integration platforms.
-   - `Shell completion scripts <https://github.com/godotengine/godot/tree/master/misc/dist/shell>`__
+   - `Shell completion scripts <https://github.com/Redot-Engine/redot-engine/tree/master/misc/dist/shell>`__
      are available for Bash, zsh and fish.
    - Print colored text to standard output on all platforms using
      :ref:`print_rich <class_@GlobalScope_method_print_rich>`.
@@ -768,7 +767,7 @@ Miscellaneous
    - Can be :ref:`compiled <doc_introduction_to_the_buildsystem>` using GCC,
      Clang and MSVC. MinGW is also supported.
    - Friendly towards packagers. In most cases, system libraries can be used
-     instead of the ones provided by Godot. The build system doesn't download anything.
+     instead of the ones provided by Redot. The build system doesn't download anything.
      Builds can be fully reproducible.
 
 - Licensed under the permissive MIT license.
@@ -777,6 +776,6 @@ Miscellaneous
 
 .. seealso::
 
-    The `Godot proposals repository <https://github.com/godotengine/godot-proposals>`__
+    The `Redot proposals repository <https://github.com/Redot-Engine/redot-proposals>`__
     lists features that have been requested by the community and may be implemented
-    in future Godot releases.
+    in future Redot releases.

--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -2,18 +2,18 @@
 
 .. _doc_release_policy:
 
-Godot release policy
+Redot release policy
 ====================
 
-Godot's release policy is in constant evolution. The description below
+Redot's release policy is in constant evolution. The description below
 provides a general idea of what to expect, but what will actually
 happen depends on the choices of core contributors and the needs of the
 community at a given time.
 
-Godot versioning
+Redot versioning
 ----------------
 
-Godot loosely follows `Semantic Versioning <https://semver.org/>`__ with a
+Redot loosely follows `Semantic Versioning <https://semver.org/>`__ with a
 ``major.minor.patch`` versioning system, albeit with an interpretation of each
 term adapted to the complexity of a game engine:
 
@@ -21,7 +21,7 @@ term adapted to the complexity of a game engine:
   which imply significant porting work to move projects from one major version
   to another.
 
-  For example, porting Godot projects from Godot 3.x to Godot 4.x requires
+  For example, porting Redot projects from Redot 3.x to Redot 4.x requires
   running the project through a conversion tool, and then performing a number
   of further adjustments manually for what the tool could not do automatically.
 
@@ -30,7 +30,7 @@ term adapted to the complexity of a game engine:
   areas *may* happen in minor versions, but the vast majority of projects
   should not be affected or require significant porting work.
 
-  This is because Godot, as a game engine, covers many areas like rendering,
+  This is because Redot, as a game engine, covers many areas like rendering,
   physics, and scripting. Fixing bugs or implementing new features in one area
   might sometimes require changing a feature's behavior or modifying a class's
   interface, even if the rest of the engine API remains backwards compatible.
@@ -82,40 +82,43 @@ on GitHub.
 +--------------+----------------------+--------------------------------------------------------------------------+
 | **Version**  | **Release date**     | **Support level**                                                        |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.3    | June 2024            | |unstable| *Development.* Receives new features, usability and           |
+| Redot 4.4    | Q1 2025              | |unstable| *Development.* Receives new features, usability and           |
 | (`master`)   | (estimate)           | performance improvements, as well as bug fixes, while under development. |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.2    | November 2023        | |supported| Receives fixes for bugs and security issues, as well as      |
+| Redot 4.3    | October 2024         | |supported| *Development.* Receives new features, usability and          |
+|              | (estimate)           | performance improvements, as well as bug fixes, while under development. |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Redot 4.2    | November 2023        | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.1    | July 2023            | |supported| Receives fixes for bugs and security issues, as well as      |
+| Redot 4.1    | July 2023            | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.0    | March 2023           | |eol| No longer supported (last update: 4.0.4).                          |
+| Redot 4.0    | March 2023           | |eol| No longer supported (last update: 4.0.4).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.6    | Q1 2024 (estimate)   | |supported| *Beta.* Receives new features, usability and performance     |
+| Redot 3.6    | Q1 2024 (estimate)   | |supported| *Beta.* Receives new features, usability and performance     |
 | (`3.x`, LTS) |                      | improvements, as well as bug fixes, while under development.             |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.5    | August 2022          | |supported| Receives fixes for bugs and security issues, as well as      |
+| Redot 3.5    | August 2022          | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.4    | November 2021        | |eol| No longer supported (last update: 3.4.5).                          |
+| Redot 3.4    | November 2021        | |eol| No longer supported (last update: 3.4.5).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.3    | April 2021           | |eol| No longer supported (last update: 3.3.4).                          |
+| Redot 3.3    | April 2021           | |eol| No longer supported (last update: 3.3.4).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.2    | January 2020         | |eol| No longer supported (last update: 3.2.3).                          |
+| Redot 3.2    | January 2020         | |eol| No longer supported (last update: 3.2.3).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.1    | March 2019           | |eol| No longer supported (last update: 3.1.2).                          |
+| Redot 3.1    | March 2019           | |eol| No longer supported (last update: 3.1.2).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.0    | January 2018         | |eol| No longer supported (last update: 3.0.6).                          |
+| Redot 3.0    | January 2018         | |eol| No longer supported (last update: 3.0.6).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 2.1    | July 2016            | |eol| No longer supported (last update: 2.1.6).                          |
+| Redot 2.1    | July 2016            | |eol| No longer supported (last update: 2.1.6).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 2.0    | February 2016        | |eol| No longer supported (last update: 2.0.4.1).                        |
+| Redot 2.0    | February 2016        | |eol| No longer supported (last update: 2.0.4.1).                        |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 1.1    | May 2015             | |eol| No longer supported.                                               |
+| Redot 1.1    | May 2015             | |eol| No longer supported.                                               |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 1.0    | December 2014        | |eol| No longer supported.                                               |
+| Redot 1.0    | December 2014        | |eol| No longer supported.                                               |
 +--------------+----------------------+--------------------------------------------------------------------------+
 
 .. |supported| image:: img/supported.png
@@ -129,29 +132,29 @@ on GitHub.
 |eol| No support (end of life) –
 |unstable| Development version
 
-Pre-release Godot versions aren't intended to be used in production and are
+Pre-release Redot versions aren't intended to be used in production and are
 provided for testing purposes only.
 
 .. seealso::
 
-    See :ref:`doc_upgrading_to_godot_4` for instructions on migrating a project
-    from Godot 3.x to 4.x.
+    See :ref:`doc_upgrading_to_redot_4` for instructions on migrating a project
+    from Redot 3.x to 4.x.
 
 .. _doc_release_policy_which_version_should_i_use:
 
 Which version should I use for a new project?
 ---------------------------------------------
 
-We recommend using Godot 4.x for new projects, as the Godot 4.x series will be
+We recommend using Redot 4.x for new projects, as the Redot 4.x series will be
 supported long after 3.x stops receiving updates in the future. One caveat is
-that a lot of third-party documentation hasn't been updated for Godot 4.x yet.
-If you have to follow a tutorial designed for Godot 3.x, we recommend keeping
-:ref:`doc_upgrading_to_godot_4` open in a separate tab to check which methods
+that a lot of third-party documentation hasn't been updated for Redot 4.x yet.
+If you have to follow a tutorial designed for Redot 3.x, we recommend keeping
+:ref:`doc_upgrading_to_redot_4` open in a separate tab to check which methods
 have been renamed (if you get a script error while trying to use a specific node
-or method that was renamed in Godot 4.x).
+or method that was renamed in Redot 4.x).
 
 If your project requires a feature that is missing in 4.x (such as GLES2/WebGL
-1.0), you should use Godot 3.x for a new project instead.
+1.0), you should use Redot 3.x for a new project instead.
 
 .. _doc_release_policy_should_i_upgrade_my_project:
 
@@ -196,7 +199,7 @@ features that come with 4.0+.
 When is the next release out?
 -----------------------------
 
-While Godot contributors aren't working under any deadlines, we strive to
+While Redot contributors aren't working under any deadlines, we strive to
 publish minor releases relatively frequently.
 
 In particular, after the very length release cycle for 4.0, we are pivoting to
@@ -212,9 +215,9 @@ Maintenance (patch) releases are released as needed with potentially very
 short development cycles, to provide users of the current stable branch with
 the latest bug fixes for their production needs.
 
-The 3.6 release is still planned and should be the last stable branch of Godot
+The 3.6 release is still planned and should be the last stable branch of Redot
 3.x. It will be a Long-Term Support (LTS) release, which we plan to support for
-as long as users still need it (due to missing features in Godot 4.x, or
+as long as users still need it (due to missing features in Redot 4.x, or
 having published games which they need to keep updating for platform
 requirements).
 
@@ -225,12 +228,12 @@ What are the criteria for compatibility across engine versions?
 
     This section is intended to be used by contributors to determine which
     changes are safe for a given release. The list is not exhaustive; it only
-    outlines the most common situations encountered during Godot's development.
+    outlines the most common situations encountered during Redot's development.
 
 The following changes are acceptable in patch releases:
 
 - Fixing a bug in a way that has no major negative impact on most projects, such
-  as a visual or physics bug. Godot's physics engine is not deterministic, so
+  as a visual or physics bug. Redot's physics engine is not deterministic, so
   physics bug fixes are not considered to break compatibility. If fixing a bug
   has a negative impact that could impact a lot of projects, it should be made
   optional (e.g. using a project setting or separate method).
@@ -266,7 +269,7 @@ performed in a new major release:
   projects. To only affect new projects, the project manager should write a
   modified ``project.godot`` instead.
 
-Since Godot 5.0 hasn't been branched off yet, we currently discourage making
+Since Redot 5.0 hasn't been branched off yet, we currently discourage making
 compatibility-breaking changes of this kind.
 
 .. note::

--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -7,12 +7,12 @@ System requirements
 
 This page contains system requirements for the editor and exported projects.
 These specifications are given for informative purposes only, but they can be
-referred to if you're looking to build or upgrade a system to use Godot on.
+referred to if you're looking to build or upgrade a system to use Redot on.
 
-Godot editor
+Redot editor
 ------------
 
-These are the **minimum** specifications required to run the Godot editor and work
+These are the **minimum** specifications required to run the Redot editor and work
 on a simple 2D or 3D project:
 
 Desktop or laptop PC - Minimum
@@ -65,11 +65,11 @@ Desktop or laptop PC - Minimum
     regularly tested and some features may be missing (such as colored
     :ref:`print_rich <class_@GlobalScope_method_print_rich>` console output).
     Support for Windows 7/8/8.1 may be removed in a
-    :ref:`future Godot 4.x release <doc_release_policy>`.
+    :ref:`future Redot 4.x release <doc_release_policy>`.
 
     Vulkan drivers for these Windows versions are known to have issues with
     memory leaks. As a result, it's recommended to stick to the Compatibility
-    rendering method when running Godot on a Windows version older than 10.
+    rendering method when running Redot on a Windows version older than 10.
 
 Mobile device (smartphone/tablet) - Minimum
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +106,7 @@ Mobile device (smartphone/tablet) - Minimum
 +----------------------+-----------------------------------------------------------------------------------------+
 
 These are the **recommended** specifications to get a smooth experience with the
-Godot editor on a simple 2D or 3D project:
+Redot editor on a simple 2D or 3D project:
 
 Desktop or laptop PC - Recommended
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -178,7 +178,7 @@ Mobile device (smartphone/tablet) - Recommended
 |                      |   Samsung Internet                                                                      |
 +----------------------+-----------------------------------------------------------------------------------------+
 
-Exported Godot project
+Exported Redot project
 ----------------------
 
 .. warning::
@@ -193,11 +193,11 @@ Exported Godot project
     It is strongly recommended to do your own testing on low-end hardware to
     make sure your project runs at the desired speed. To provide scalability for
     low-end hardware, you will also need to introduce a
-    `graphics options menu <https://github.com/godotengine/godot-demo-projects/tree/master/3d/graphics_settings>`__
+    `graphics options menu <https://github.com/Redot-Engine/redot-demo-projects/tree/master/3d/graphics_settings>`__
     to your project.
 
 These are the **minimum** specifications required to run a simple 2D or 3D
-project exported with Godot:
+project exported with Redot:
 
 Desktop or laptop PC - Minimum
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,11 +247,11 @@ Desktop or laptop PC - Minimum
     regularly tested and some features may be missing (such as colored
     :ref:`print_rich <class_@GlobalScope_method_print_rich>` console output).
     Support for Windows 7/8/8.1 may be removed in a
-    :ref:`future Godot 4.x release <doc_release_policy>`.
+    :ref:`future Redot 4.x release <doc_release_policy>`.
 
     Vulkan drivers for these Windows versions are known to have issues with
     memory leaks. As a result, it's recommended to stick to the Compatibility
-    rendering method when running Godot on a Windows version older than 10.
+    rendering method when running Redot on a Windows version older than 10.
 
 Mobile device (smartphone/tablet) - Minimum
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,7 +289,7 @@ Mobile device (smartphone/tablet) - Minimum
 +----------------------+-----------------------------------------------------------------------------------------+
 
 These are the **recommended** specifications to get a smooth experience with a
-simple 2D or 3D project exported with Godot:
+simple 2D or 3D project exported with Redot:
 
 Desktop or laptop PC - Recommended
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -365,6 +365,6 @@ Mobile device (smartphone/tablet) - Recommended
 
 .. note::
 
-    Godot doesn't use OpenGL/OpenGL ES extensions introduced after OpenGL
+    Redot doesn't use OpenGL/OpenGL ES extensions introduced after OpenGL
     3.3/OpenGL ES 3.0, but GPUs supporting newer OpenGL/OpenGL ES versions
     generally have fewer driver issues.


### PR DESCRIPTION
This pr is for about section rebranding only in **stable** branch
Rebranding has lot of changes, so pulling only few at a time section by section. 

It does not cover the PR https://github.com/Redot-Engine/redot-docs/pull/23

Note: The following issues needs to be addressed as separate
1. Links to redotengine website are not available, it needs to be fixed (will create separate issue for it)
2. Release policy needs to be updated based on the roadmap. 
3. Lot more changes needs to be done based on context, that will be gradually done, e.g., removing GD Native content support