### PR TITLE
Updated binary names in "Using the command line" section under "Upgrading from Redot 3 to Redot 4" document.

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -147,7 +147,7 @@ it's recommended to validate the project conversion by running the Godot editor 
 
     # [<max_file_kb>] [<max_line_size>] are optional arguments.
     # Remove them if you aren't changing their values.
-    path/to/godot.binary --path /path/to/project/folder --validate-conversion-3to4 [<max_file_kb>] [<max_line_size>]
+    path/to/redot.binary --path /path/to/project/folder --validate-conversion-3to4 [<max_file_kb>] [<max_line_size>]
 
 If the list of planned upgrades looks good to you, run the following command on
 the Godot editor binary to upgrade project files:
@@ -156,7 +156,7 @@ the Godot editor binary to upgrade project files:
 
     # [<max_file_kb>] [<max_line_size>] are optional arguments.
     # Remove them if you aren't changing their values.
-    path/to/godot.binary --path /path/to/project/folder --convert-3to4 [<max_file_kb>] [<max_line_size>]
+    path/to/redot.binary --path /path/to/project/folder --convert-3to4 [<max_file_kb>] [<max_line_size>]
 
 ``[<max_file_kb>]`` and ``[<max_line_size>]`` are *optional* arguments to specify
 the maximum size of files to be converted (in kilobytes and lines). The default
@@ -171,7 +171,7 @@ running the Godot editor binary with those arguments increases both limits by a
 
 ::
 
-    path/to/godot.binary --path /path/to/project/folder --convert-3to4 40000 1000000
+    path/to/redot.binary --path /path/to/project/folder --convert-3to4 40000 1000000
 
 .. note::
 


### PR DESCRIPTION
Hello devs! :)

In "Upgrading from Redot 3 to Redot 4" document, I saw the commands under "Using the command line" section still mentions `godot.binary` instead of `redot.binary` —

![image](https://github.com/user-attachments/assets/edde757b-e73f-48b0-8b5e-cddf06fc38b7)

Made this PR to fix that...

<!--
Please target one of `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.redotengine.org/community/contributing/content_guidelines.html
-->
