### PR TITLE
Fixed broken links to repositories

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -41,6 +41,6 @@ Devlogs
 Resources
 ---------
 
-- `awesome-godot: A curated list of free/libre plugins, scripts and add-ons <https://github.com/godotengine/awesome-godot>`_
+- `redot-awesome: A curated list of free/libre plugins, scripts and add-ons <https://github.com/redot-engine/redot-awesome>`_
 - `Godot Asset Library <https://godotengine.org/asset-library/asset>`_
 - `Godot Shaders: A community-driven shader library <https://godotshaders.com/>`_

--- a/contributing/workflow/first_steps.rst
+++ b/contributing/workflow/first_steps.rst
@@ -54,7 +54,7 @@ way more contributions than people validating them.
 
 To make sure that your time and efforts aren't wasted, it is recommended to vet the idea
 first before implementing it and putting it for a review as a PR. To that end, Godot
-has a `proposal system <https://github.com/godotengine/godot-proposals>`_. Its
+has a `proposal system <https://github.com/Redot-Engine/redot-proposals>`_. Its
 usage is encouraged to plan changes and discuss them with the community. Implementation
 details can also be discussed with other contributors on the `Godot Contributors Chat <https://chat.godotengine.org/>`_.
 


### PR DESCRIPTION
<!--
Please target one of `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.redotengine.org/community/contributing/content_guidelines.html
-->
Fixed broken links to the redot-awesome and redot-proposal repositories mentioned in issues #61 and #33, respectively.