### PR TITLE
Add Redot 26.1 LTS documentation branch

### DIFF
--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -1,7 +1,7 @@
 {# Add rst-badge after rst-versions for small badge style. #}
 {% set display_version = version -%}
 {% set listed_languages = ({"en":"#", "de":"#", "es":"#", "fr":"#"}).items() -%}
-{% set listed_versions = ({"stable":"#", "latest":"#"}).items() -%}
+{% set listed_versions = ({"26.1":"/"}).items() -%}
 
 {% if READTHEDOCS and current_version %}
   {% set display_version = current_version -%}

--- a/conf.py
+++ b/conf.py
@@ -59,13 +59,11 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 # This makes it easier to test the custom 404 page by loading `/404.html`
 # on a local web server.
 if not on_rtd:
-    notfound_urls_prefix = ''
+    notfound_urls_prefix = ""
 
 # Specify the site name for the Open Graph extension.
 ogp_site_name = "Godot Engine documentation"
-ogp_social_cards = {
-    "enable": False
-}
+ogp_social_cards = {"enable": False}
 
 if not os.getenv("SPHINX_NO_GDSCRIPT"):
     extensions.append("gdscript")
@@ -84,9 +82,7 @@ master_doc = "index"
 
 # General information about the project
 project = "Godot Engine"
-copyright = (
-    "2024-present by the Redot community, modified from an original work by Juan Linietsky, Ariel Manzur and the G-dot community (CC BY 3.0)"
-)
+copyright = "2024-present by the Redot community, modified from an original work by Juan Linietsky, Ariel Manzur and the G-dot community (CC BY 3.0)"
 author = "the Redot community, modified from an original work by Juan Linietsky, Ariel Manzur and the G-dot community"
 
 # Version info for the project, acts as replacement for |version| and |release|
@@ -177,7 +173,7 @@ html_theme_options = {
     "flyout_display": "attached",
 }
 
-html_title = supported_languages[language] % ( "(" + version + ")" )
+html_title = supported_languages[language] % ("(" + version + ")")
 
 # Edit on GitHub options: https://docs.readthedocs.io/en/latest/guides/edit-source-links-sphinx.html
 html_context = {
@@ -195,7 +191,7 @@ html_context = {
     # Set this to `True` when in the `latest` branch to clearly indicate to the reader
     # that they are not reading the `stable` documentation.
     "godot_is_latest": True,
-    "godot_version": "4.4",
+    "godot_version": "26.1",
     # Enables a banner that displays the up-to-date status of each article.
     "godot_show_article_status": True,
     # Display user-contributed notes at the bottom of pages that don't have `:allow_comments: False` at the top.
@@ -289,6 +285,7 @@ def godot_get_image_filename_for_language(filename, env):
     path = os.path.abspath(os.path.join("../images/", os.path.relpath(path, cwd)))
     return path
 
+
 sphinx.util.i18n.get_image_filename_for_language = godot_get_image_filename_for_language
 
 # Similar story for the localized class reference, it's out of tree and there doesn't
@@ -305,4 +302,4 @@ if is_i18n and os.path.exists("../classes/" + language):
     os.symlink("../classes/" + language, "classes")
 
 # Needed so the table of contents is created for EPUB
-epub_tocscope = 'includehidden'
+epub_tocscope = "includehidden"


### PR DESCRIPTION
This PR creates the 26.1 branch with:

- Version label set to 26.1 in conf.py
- Version selector showing only 26.1

This is the foundation for the 26.1 LTS documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version from 4.4 to 26.1.
  * Simplified documentation version links to reference the current version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->