### PR TITLE
Fix: Change Cloudflare deploy branch from main to master

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -114,4 +114,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy . --project-name=redot-docs --branch=main
+          command: pages deploy . --project-name=redot-docs --branch=master


### PR DESCRIPTION
**Fix:** Changed Cloudflare Pages deployment branch from `main` to `master`.

**Problem:** Deployments were showing under 'main' in Cloudflare Pages but the repository uses 'master' branch.

**Solution:** Updated deploy command to use `--branch=master` instead of `--branch=main`.

This is a one-line fix to ensure deployments properly associate with the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment target configuration for Cloudflare Pages deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->